### PR TITLE
Support laravel 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ composer.phar
 composer.lock
 build
 .php_cs.cache
+coverage
+.idea
+.phpunit*

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.3",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6.3",
-    "illuminate/support": "^5.5|^6.0|^7.0"
+    "guzzlehttp/guzzle": "^6.3|^7.0",
+    "illuminate/support": "^7.0|^8.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",
-    "phpunit/phpunit": "^7.0",
-    "mockery/mockery": "^0.9",
-    "orchestra/testbench": "^3.6"
+    "phpunit/phpunit": "^8.0|^9.0",
+    "mockery/mockery": "^1.0",
+    "orchestra/testbench": "^5.0|^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <!--    <php>-->
+    <!--        <env name="LOG_DISCORD_WEBHOOK_URL" value="https://discordapp.com/api/webhooks/..."/>-->
+    <!--    </php>-->
+</phpunit>


### PR DESCRIPTION
Hi, I wasn't sure if you wanted to keep `roave/security-advisories` as a dependency, but if so support for laravel <6 had to be removed, and therefore php 7.1.

Tests pass for me for php 7.3 and 7.4, both with and without --prefer-lowest, but on travis there seemed to be a small difference regarding crlf in `SimpleLoggerMessagesTest::includes_stacktrace_in_content_when_attachment_disabled` [for some of the environments](https://travis-ci.com/github/miraries/laravel-discord-logger/jobs/383192332). Either way I didn't want to add it without consulting first.

References https://github.com/marvinlabs/laravel-discord-logger/issues/15