### PR TITLE
RichRecordConverter don't show filename and line on exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All Notable changes to `laravel-discord-logger` will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- RichRecordConverter don't show filename and line on exceptions (#22).
+
 ## 1.0.0 - 2019/05/30
 
 - Initial release

--- a/src/DiscordLogger/Converters/AbstractRecordConverter.php
+++ b/src/DiscordLogger/Converters/AbstractRecordConverter.php
@@ -55,9 +55,7 @@ abstract class AbstractRecordConverter implements RecordToMessage
 
     protected function getStacktrace(array $record): ?string
     {
-        if (empty($record['context'])
-            || empty($record['context']['exception'])
-            || !is_a($record['context']['exception'], Throwable::class))
+        if (!is_a($record['context']['exception'] ?? '', Throwable::class))
         {
             return null;
         }
@@ -65,7 +63,9 @@ abstract class AbstractRecordConverter implements RecordToMessage
         /** @var \Throwable $exception */
         $exception = $record['context']['exception'];
 
-        return $exception->getTraceAsString();
+        return "On {$exception->getFile()}:{$exception->getLine()} (code {$exception->getCode()})\n" .
+            "Stacktrace:\n" .
+            $exception->getTraceAsString();
     }
 
     protected function getRecordColor(array $record): int

--- a/src/DiscordLogger/Converters/RichRecordConverter.php
+++ b/src/DiscordLogger/Converters/RichRecordConverter.php
@@ -88,7 +88,7 @@ class RichRecordConverter extends AbstractRecordConverter
     {
         $message->embed(Embed::make()
             ->color($this->getRecordColor($record))
-            ->title('Stacktrace')
+            ->title('Exception')
             ->description("`$stacktrace`"));
     }
 }

--- a/tests/Converters/RichLoggerMessagesTest.php
+++ b/tests/Converters/RichLoggerMessagesTest.php
@@ -38,6 +38,18 @@ class RichLoggerMessagesTest extends AbstractLoggerMessagesTest
     }
 
     /** @test */
+    public function includes_error_filename_and_line()
+    {
+        $this->config->set('discord-logger.stacktrace', 'inline');
+
+        $exception = new Exception();
+        $message =   $this->exception('This is a test', $exception)[0];
+
+        $this->assertStringContainsString($exception->getFile(), $message->embeds[1]->description);
+        $this->assertStringContainsString($exception->getLine(), $message->embeds[1]->description);
+    }
+
+    /** @test */
     public function includes_stacktrace_in_content_when_attachment_disabled()
     {
         $this->config->set('discord-logger.stacktrace', 'inline');
@@ -68,8 +80,8 @@ class RichLoggerMessagesTest extends AbstractLoggerMessagesTest
         ], $messages[0]);
 
         MessageAssertions::assertMessagePartialMatch([
-            'file' => ['filename' => '20000101121314_stacktrace.txt',
-                       'contents' => $exception->getTraceAsString(),],
+            'file' => ['filename' => '20000101121314_stacktrace.txt'],
         ], $messages[1]);
+        $this->assertStringContainsString($exception->getTraceAsString(), $messages[1]->file['contents']);
     }
 }

--- a/tests/Converters/SimpleLoggerMessagesTest.php
+++ b/tests/Converters/SimpleLoggerMessagesTest.php
@@ -40,6 +40,18 @@ class SimpleLoggerMessagesTest extends AbstractLoggerMessagesTest
     }
 
     /** @test */
+    public function includes_error_filename_and_line()
+    {
+        $this->config->set('discord-logger.stacktrace', 'inline');
+
+        $exception = new Exception();
+        $message =   $this->exception('This is a test', $exception)[0];
+
+        $this->assertStringContainsString($exception->getFile(), $message->content);
+        $this->assertStringContainsString($exception->getLine(), $message->content);
+    }
+
+    /** @test */
     public function includes_stacktrace_in_content_when_attachment_disabled()
     {
         $this->config->set('discord-logger.stacktrace', 'inline');
@@ -62,8 +74,8 @@ class SimpleLoggerMessagesTest extends AbstractLoggerMessagesTest
         $this->assertStringContainsString('[2000-01-01 12:13:14] Laravel.CRITICAL: This is a test', $message->content);
 
         MessageAssertions::assertMessagePartialMatch([
-            'file' => ['filename' => '20000101121314_stacktrace.txt',
-                       'contents' => $exception->getTraceAsString(),],
+            'file' => ['filename' => '20000101121314_stacktrace.txt'],
         ], $message);
+        $this->assertStringContainsString($exception->getTraceAsString(), $message->file['contents']);
     }
 }


### PR DESCRIPTION
Based on #22...

#### After

```
[2021-12-16 18:31:07] production.ERROR
Call to undefined method App\Model::badMethod()

Stacktrace
`#0 /app/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php(36): Illuminate\Database\Eloquent\Model::throwBadMethodCallException()
#1 /app/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1993): Illuminate\Database\Eloquent\Model->forwardCallTo()
...
```

#### Before

```
[2021-12-16 18:31:07] production.ERROR
Call to undefined method App\Model::badMethod()

Exception
On /app/Model.php:115 (code 11)
Stacktrace:
`#0 /app/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php(36): Illuminate\Database\Eloquent\Model::throwBadMethodCallException()
#1 /app/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1993): Illuminate\Database\Eloquent\Model->forwardCallTo()
...
```