### PR TITLE
Add timestamp to embed footer

### DIFF
--- a/src/DiscordLogger/Discord/Embed.php
+++ b/src/DiscordLogger/Discord/Embed.php
@@ -35,6 +35,9 @@ class Embed implements Arrayable
     /** @var array */
     public $fields;
 
+    /** @var string */
+    public $timestamp;
+
     /** Static factory method */
     public static function make(): Embed
     {
@@ -104,6 +107,12 @@ class Embed implements Arrayable
         return $this;
     }
 
+    public function timestamp(string $timestamp): Embed
+    {
+        $this->timestamp = $timestamp;
+        return $this;
+    }
+
     public function toArray(): array
     {
         return array_filter(
@@ -117,6 +126,7 @@ class Embed implements Arrayable
                 'thumbnail'   => $this->thumbnail,
                 'author'      => $this->author,
                 'fields'      => $this->serializeFields(),
+                'timestamp'   => $this->timestamp,
             ],
             static function ($value) {
                 return $value !== null && $value !== [];

--- a/tests/Discord/EmbedTest.php
+++ b/tests/Discord/EmbedTest.php
@@ -32,7 +32,8 @@ class EmbedTest extends TestCase
             ->thumbnail('thumbnail.url')
             ->field('first-field', 'foo', true)
             ->field('second-field', 'bar', false)
-            ->footer('my footer', 'footer-icon.url');
+            ->footer('my footer', 'footer-icon.url')
+            ->timestamp('2000-01-01T12:13:14.000Z');
 
         $this->assertEquals(
             ['title'       => 'my title',
@@ -52,6 +53,7 @@ class EmbedTest extends TestCase
                                ['name'   => 'second-field',
                                 'value'  => 'bar',
                                 'inline' => false,],],
+             'timestamp'   => '2000-01-01T12:13:14.000Z',
             ],
             $embed->toArray());
     }

--- a/tests/Discord/MessageTest.php
+++ b/tests/Discord/MessageTest.php
@@ -32,7 +32,8 @@ class MessageTest extends TestCase
             ->thumbnail('thumbnail.url')
             ->field('first-field', 'foo', true)
             ->field('second-field', 'bar', false)
-            ->footer('my footer', 'footer-icon.url');
+            ->footer('my footer', 'footer-icon.url')
+            ->timestamp('2000-01-01T12:13:14.000Z');
 
         $message = Message::make()
             ->content('my content')


### PR DESCRIPTION
I've added a new method into embeds so timestamp can be shown in the footer. 

During tests I've also noticed there's an error in test: "includes_stacktrace_in_content_when_attachment_disabled", but I can't find why. This error has nothing common with the timestamp implementation and it was there before.

If there's anything I should do more or fix, let me know.