### PR TITLE
Fix: Add option to ignore exceptions using .env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ You must add a new channel to your `config/logging.php` file:
         'via'    => MarvinLabs\DiscordLogger\Logger::class,
         'level'  => 'debug',
         'url'    => env('LOG_DISCORD_WEBHOOK_URL'),
+        'ignore_exceptions' => env('LOG_DISCORD_IGNORE_EXCEPTIONS', false),
     ],
 ];
 ```


### PR DESCRIPTION
1. Add an option to disable the throwing of exceptions using .env variable `LOG_DISCORD_IGNORE_EXCEPTIONS`
2. Fix this issue in Laravel 10.
![image](https://user-images.githubusercontent.com/3089863/221088593-d41766c6-5767-456d-aed9-792ee5b2cb0d.png)

_Tested in Laravel 10_

Fixes #21 