### PR TITLE
LogRecord update for MonoLog Laravel 10

### DIFF
--- a/src/DiscordLogger/LogHandler.php
+++ b/src/DiscordLogger/LogHandler.php
@@ -9,6 +9,7 @@ use MarvinLabs\DiscordLogger\Contracts\RecordToMessage;
 use MarvinLabs\DiscordLogger\Converters\SimpleRecordConverter;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger as Monolog;
+use Monolog\LogRecord;
 use RuntimeException;
 use function class_implements;
 
@@ -29,8 +30,10 @@ class LogHandler extends AbstractProcessingHandler
         $this->recordToMessage = $this->createRecordConverter($container, $config);
     }
 
-    public function write(array $record): void
+    public function write(LogRecord $record): void
     {
+        $record = $record->toArray();
+
         foreach($this->recordToMessage->buildMessages($record) as $message)
         {
             $this->discord->send($message);


### PR DESCRIPTION
Fixes this issue

```
Declaration of MarvinLabs\DiscordLogger\LogHandler::write(array $record): void must be compatible with Monolog\Handler\AbstractProcessingHandler::write(Monolog\LogRecord $record): void
```